### PR TITLE
"data" is "params" for GET request

### DIFF
--- a/modules/katello/katello.py
+++ b/modules/katello/katello.py
@@ -53,7 +53,7 @@ class Katello(object):
 
         r = requests.get(
             self.katello_api + location,
-            data=data,
+            params=data,
             auth=(self.katello_user, self.katello_password),
             verify=self.ssl_verify,
         )


### PR DESCRIPTION
There is error in here. "data" is valid only for POST requests, so for GET there should be params not data. This error leads for example to situation when there are more than 20 repositories. In this setup pagination truncates some of them.
